### PR TITLE
ci: improve deployment process and simplify Makefile- Update deployme…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd ${{ secrets.COMPOSE_FILE_DIR }}
+            cd ${{ secrets.PROJECT_DIR }}
             git pull origin master
             docker compose --env-file ../../.env pull app
             docker compose --env-file ../../.env up -d --force-recreate app

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
-# Application
-run:
-	go run cmd/api/main.go
-
 # Docker services
 LOCAL_DOCKER_COMPOSE_PROJECT_NAME=transactions_services_local
 LOCAL_DOCKER_COMPOSE_FILE_PATH=./docker/local/docker-compose.yml
 
-PROD_DOCKER_COMPOSE_PROJECT_NAME=transactions_services_prod
+PROD_DOCKER_COMPOSE_PROJECT_NAME=transactions_services
 PROD_DOCKER_COMPOSE_FILE_PATH=./docker/prod/docker-compose.yml
 
 up_local_services:
@@ -16,14 +12,6 @@ down_local_services:
 rebuild_local_services:
 	docker compose -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) up -d --build
 restart_local_services: down_local_services up_local_services
-
-up_prod_services:
-	docker compose --env-file ./.env -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d
-down_prod_services:
-	docker compose --env-file ./.env -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) down
-rebuild_prod_services:
-	docker compose --env-file ./.env -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --build
-restart_prod_services: down_prod_services up_prod_services
 
 # Migrations(Goose)
 MIGRATIONS_DIR=migrations
@@ -38,3 +26,10 @@ add_migration:
 # Deployment
 build_prod_image:
 	docker build -f .\docker\prod\Dockerfile .
+
+deploy_prod:
+	@echo "Deploying production services..."
+	docker compose --env-file ../../.env -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) pull app
+	docker compose --env-file ../../.env -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --force-recreate app
+	@echo "Deployment complete."
+


### PR DESCRIPTION
…nt script in GitHub Actions workflow to use PROJECT_DIR instead of COMPOSE_FILE_DIR- Remove redundant production service commands from Makefile- Rename PROD_DOCKER_COMPOSE_PROJECT_NAME to a more generic name- Add deploy_prod target to Makefile for streamlined production deployment