### PR TITLE
ci: improve deployment process and simplify Makefile- Update deployme…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,7 @@ jobs:
           script: |
             cd ${{ secrets.PROJECT_DIR }}
             git pull origin master
-            docker compose --env-file ../../.env pull app
-            docker compose --env-file ../../.env up -d --force-recreate app
+            make deploy_prod
 
             echo "Waiting for the application to become healthy..."
             for i in {1..12}; do


### PR DESCRIPTION
…nt script in GitHub Actions workflow to use PROJECT_DIR instead of COMPOSE_FILE_DIR- Remove redundant production service commands from Makefile- Rename PROD_DOCKER_COMPOSE_PROJECT_NAME to a more generic name- Add deploy_prod target to Makefile for streamlined production deployment