### PR TITLE
fix(docker): update PostgreSQL port mapping- Change host port from543…

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data
     ports:
-      - "5433:5432"
+      - "5432:5432"
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 5s


### PR DESCRIPTION
…3 to5432 for PostgreSQL service- This ensures consistency between local and default PostgreSQL ports