### PR TITLE
build: replace docker-compose with docker compose- Update Makefile to…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,20 @@ ALEMBIC_CONFIG=./migrations/alembic.ini
 ######    Shortcuts    ######
 # Local Docker Services
 up_local_services:
-	docker-compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) up -d
+	docker compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) up -d
 down_local_services:
-	docker-compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) down
+	docker compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) down
 rebuild_local_services:
-	docker-compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) up -d --build
+	docker compose --env-file ${ENV_LOCAL_PATH} -p $(LOCAL_DOCKER_COMPOSE_PROJECT_NAME) -f $(LOCAL_DOCKER_COMPOSE_FILE_PATH) up -d --build
 restart_local_services: down_local_services up_local_services
 
 # Production Docker Services
 up_prod_services:
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d
 down_prod_services:
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) down
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) down
 rebuild_prod_services:
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --build
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --build
 restart_prod_services: down_prod_services up_prod_services
 
 # Migrations (Alembic)
@@ -42,9 +42,9 @@ create_migration:
 # Deployment
 deploy_prod:
 	@echo "Deploying production services..."
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) pull app
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --force-recreate app
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) pull app
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) up -d --force-recreate app
 	@echo "Deployment complete."
 
 health_check_prod:
-	docker-compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) ps app
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) ps app


### PR DESCRIPTION
… use the new Docker Compose CLI command- Replace all instances of 'docker-compose' with 'docker compose'- This change aligns with Docker's deprecation of the standalone docker-compose binary