### PR TITLE
feat(Makefile): add logs_prod command for production environment- Int…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ deploy_prod:
 
 health_check_prod:
 	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) ps app
+
+logs_prod:
+	docker compose --env-file ${ENV_PROD_PATH} -p $(PROD_DOCKER_COMPOSE_PROJECT_NAME) -f $(PROD_DOCKER_COMPOSE_FILE_PATH) logs app


### PR DESCRIPTION
…roduce a new make command `logs_prod` to view application logs in the production environment- Maintain consistency with existing health_check_prod command structure- Enhance operational capabilities for production environment management