### PR TITLE
build(docker): update Dockerfile and entrypoint for uv-based setup- S…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ restart_prod_services: down_prod_services up_prod_services
 
 # Migrations (Alembic)
 apply_migrations:
-	uv run alembic -c ${ALEMBIC_CONFIG} upgrade head
+	alembic -c ${ALEMBIC_CONFIG} upgrade head
 
 create_migration:
-	uv run alembic -c ${ALEMBIC_CONFIG} revision --autogenerate -m "$(name)"
+	alembic -c ${ALEMBIC_CONFIG} revision --autogenerate -m "$(name)"
 
 # Deployment
 deploy_prod:

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -14,8 +14,9 @@ RUN uv sync --locked --no-dev
 
 COPY . .
 
-FROM python:3.13-slim-trixie
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 
+ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV VENV_PATH=/opt/venv
@@ -29,8 +30,9 @@ RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USE
 WORKDIR /app
 
 COPY --from=builder ${VENV_PATH} ${VENV_PATH}
-
 COPY --from=builder /app /app
+
+ENV UV_CACHE_DIR=/tmp/uv_cache
 
 COPY ./docker/prod/scripts/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh

--- a/docker/prod/scripts/entrypoint.sh
+++ b/docker/prod/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-make apply_migrations
+uv run make apply_migrations
 
-exec uvicorn main:app --host 0.0.0.0 --port "${INTERNAL_PORT}"
+uv run uvicorn main:app --host 0.0.0.0 --port "${INTERNAL_PORT}"


### PR DESCRIPTION
…witch to astral-sh/uv image for improved caching and security- Update entrypoint.sh to use uv commands for migrations and server start- Modify Makefile to remove uv run prefix for alembic commands- Add UV_CACHE_DIR environment variable for improved build performance- Adjust PATH to include local bin directory